### PR TITLE
Don't open gleebox when focus is in a select box

### DIFF
--- a/Chrome/glee_chrome/js/Utils.js
+++ b/Chrome/glee_chrome/js/Utils.js
@@ -271,7 +271,7 @@ var Utils = {
 	elementCanReceiveUserInput: function(el) {
         var tag = el.tagName.toLowerCase();
 		// list of elements which can receive input. Should be avoided while listening to window keystrokes
-	 	var blacklist = ['input', 'textarea', 'div', 'object', 'embed'];
+	 	var blacklist = ['input', 'textarea', 'div', 'object', 'embed', 'select'];
 	
 		return ($.inArray(tag, blacklist) != -1) || el.contentEditable === "true";
 	}


### PR DESCRIPTION
When I hit `g` in a select box, I expect to select the first item starting with a `g` in the select's options, but I get a gleebox instead. This is to fix that.
