### PR TITLE
Allow disabling of non-alt shortcuts

### DIFF
--- a/Chrome/glee_chrome/js/background.js
+++ b/Chrome/glee_chrome/js/background.js
@@ -10,6 +10,7 @@ var cache = {
        scrollingSpeed: 500,
        outsideScrolling: false,
        shortcutKey: 71,
+       requireAlt: false,
        upScrollingKey: 87,
        downScrollingKey: 83,
        tabManager: true,

--- a/Chrome/glee_chrome/js/glee.js
+++ b/Chrome/glee_chrome/js/glee.js
@@ -37,6 +37,8 @@ var Glee = {
     options: {
         // Keydown code of shortcut key to launch gleeBox
         shortcutKey: 71,
+        // Disable using the shortcut key without pressing alt. (Not scrolling shortcuts.)
+        requireAlt: false,
         // Keydown code of shortcut key to launch tab manager
         tabManagerShortcutKey: 190,
         // Size of gleeBox (small, medium, large)
@@ -843,7 +845,7 @@ var Glee = {
         $(window).bind('keydown', function(e) {
             var target = e.target || e.srcElement;
             if (Glee.status) {
-                if (!Utils.elementCanReceiveUserInput(target) || e.altKey) {
+                if (!Glee.options.requireAlt && !Utils.elementCanReceiveUserInput(target) || e.altKey) {
                     if (target.id === 'gleeSearchField')
                         return true;
 

--- a/Chrome/glee_chrome/options.html
+++ b/Chrome/glee_chrome/options.html
@@ -112,6 +112,15 @@
 
                         <div>
                             <label>
+                                <input name="requireAlt" type="checkbox" />
+                                <span class="option">
+                                    Shortcuts only work with alt pressed. Does not affect the scrolling shortcuts.
+                                </span>
+                            </label>
+                        </div>
+
+                        <div>
+                            <label>
                                 <span class="option">
                                     Smooth Scrolling Shortcut:
                                 </span>


### PR DESCRIPTION
When checked, shortcuts will only work when the alt key is pressed. (Does not affect scrolling shortcuts.)

This enables a mode where the addon is less intrusive with sites that
already has keybindings.
