### PR TITLE
Fix for Quix prompting for update of bookmarklet

### DIFF
--- a/Chrome/glee_chrome/js/events.js
+++ b/Chrome/glee_chrome/js/events.js
@@ -365,7 +365,7 @@ Glee.Events = {
             var d = '' + document.location;
             u = u + '&t=' + (document.title ? encodeURIComponent(document.title) : '')
             + '&s=' + Glee.options.quixUrl
-            + '&v=080'
+            + '&v=081'
             + '&u=' + (document.location ? encodeURIComponent(document.location) : '');
 
             if (executeInNewTab) {

--- a/Safari/gleeBox.safariextension/js/events.js
+++ b/Safari/gleeBox.safariextension/js/events.js
@@ -365,7 +365,7 @@ Glee.Events = {
             var d = '' + document.location;
             u = u + '&t=' + (document.title ? encodeURIComponent(document.title) : '')
             + '&s=' + Glee.options.quixUrl
-            + '&v=080'
+            + '&v=081'
             + '&u=' + (document.location ? encodeURIComponent(document.location) : '');
 
             if (executeInNewTab) {


### PR DESCRIPTION
If using Quix as the command engine, Quix is asking you to update to the latest version of the bookmarklet. This change bumps up the version being sent in the URL
