### PR TITLE
Backspace tolerance

### DIFF
--- a/Chrome/glee_chrome/js/events.js
+++ b/Chrome/glee_chrome/js/events.js
@@ -69,7 +69,7 @@ Glee.Events = {
       // if the user is not holding the backspace key or ragepressing it
       if (!Glee.isDeleting && Glee.isEmpty())
         window.history.back();
-      
+
       Glee.isDeleting = true;
     }
   },
@@ -118,7 +118,7 @@ Glee.Events = {
           if (Glee.options.bookmarkSearchStatus) {
             Glee.bookmarks = [];
           }
-          
+
           Glee.resetTimer();
           Glee.setSearchActivity(false);
           var command = value.substring(1);
@@ -164,7 +164,7 @@ Glee.Events = {
       // you're not pulled up to another position on the page
       Glee.selectTopElement();
     }
-    
+
     // Backspace key: set the deleting state to false
     if (e.keyCode === 8 && Glee.isEmpty()) {
       Glee.resetTimer();
@@ -172,7 +172,7 @@ Glee.Events = {
         Glee.isDeleting = false;
       }, Glee.defaults.backspaceToleranceTimer);
     }
-    
+
   },
 
   /**

--- a/Chrome/glee_chrome/js/glee.js
+++ b/Chrome/glee_chrome/js/glee.js
@@ -18,7 +18,7 @@ var Glee = {
     cacheSize: 20,
 
     linkSearchTimer: 0,
-    
+
     backspaceToleranceTimer: 500,
 
     themes: [

--- a/Safari/gleeBox.safariextension/js/events.js
+++ b/Safari/gleeBox.safariextension/js/events.js
@@ -65,8 +65,12 @@ Glee.Events = {
     }
 
     //  Backspace takes user back in history if gleeBox is empty
-    else if (e.keyCode === 8 && Glee.isEmpty()) {
-      window.history.back();
+    else if (e.keyCode === 8) {
+      // if the user is not holding the backspace key or ragepressing it
+      if (!Glee.isDeleting && Glee.isEmpty())
+        window.history.back();
+
+      Glee.isDeleting = true;
     }
   },
 
@@ -114,7 +118,7 @@ Glee.Events = {
           if (Glee.options.bookmarkSearchStatus) {
             Glee.bookmarks = [];
           }
-          
+
           Glee.resetTimer();
           Glee.setSearchActivity(false);
           var command = value.substring(1);
@@ -160,6 +164,15 @@ Glee.Events = {
       // you're not pulled up to another position on the page
       Glee.selectTopElement();
     }
+
+    // Backspace key: set the deleting state to false
+    if (e.keyCode === 8 && Glee.isEmpty()) {
+      Glee.resetTimer();
+      Glee.timer = setTimeout(function() {
+        Glee.isDeleting = false;
+      }, Glee.defaults.backspaceToleranceTimer);
+    }
+
   },
 
   /**

--- a/Safari/gleeBox.safariextension/js/glee.js
+++ b/Safari/gleeBox.safariextension/js/glee.js
@@ -19,6 +19,8 @@ var Glee = {
 
     linkSearchTimer: 0,
 
+    backspaceToleranceTimer: 500,
+
     themes: [
       'GleeThemeDefault',
       'GleeThemeWhite',
@@ -114,6 +116,7 @@ var Glee = {
   // last query executed in jQuery mode
   lastjQuery: null,
   isSearching: false,
+  isDeleting: false,
   isEspRunning: false,
   isDOMSearchRequired: true,
   commandMode: false,


### PR DESCRIPTION
I noticed that whenever the user is holding the backspace key to delete everything he has just typed Gleebox will erroneously take the user back in history, and the same behaviour occours when the user is pressing the backspace key multiple times (as explained in Issue #224) so I added a tolerance check for the backspace key.
