### PR TITLE
Use Shift-Control-Enter to open links in new tab with focus

### DIFF
--- a/Chrome/glee_chrome/js/events.js
+++ b/Chrome/glee_chrome/js/events.js
@@ -448,6 +448,7 @@ Glee.Events = {
   */
   execute: function(e, value) {
     var executeInNewTab = e.shiftKey || e.ctrlKey || e.metaKey;
+    var executeInNewTabWithFocus = e.shiftKey && (e.ctrlKey || e.metaKey);
 
     if (Glee.isJQueryCmd() && value != Glee.lastjQuery) {
       Glee.Events.executeJQuerySelector(value.substring(1));
@@ -494,7 +495,7 @@ Glee.Events = {
           a_el.attr('target', '_self');
 
           // Simulating a click on the link
-          anythingOnClick = Utils.simulateClick(a_el.get(0), target);
+          anythingOnClick = Utils.simulateClick(a_el.get(0), target, executeInNewTabWithFocus);
 
           // If opening link on the same page, close gleeBox
           if (!target) {
@@ -546,7 +547,7 @@ Glee.Events = {
             || tag === 'button') {
           
           setTimeout(function() {
-            Utils.simulateClick(el, false);
+            Utils.simulateClick(el, false, false);
             Glee.blur();
           }, 0);
         }

--- a/Chrome/glee_chrome/js/libs/utils.js
+++ b/Chrome/glee_chrome/js/libs/utils.js
@@ -151,16 +151,19 @@ var Utils = {
     /**
      *  Simulates a click on an element.
      *  @param {Element} el DOM element to simulate click on.
-     *  @param {boolean} Set to true if the link should be opened in a new tab.
+     *  @param {boolean} target Set to true if the link should be opened in a new tab.
+     *  @param {boolean} focus Set to true if the link should be opened in a new tab with focus. Overrides target.
      *  @return {Event} The Click event.
      */
-    simulateClick: function(el, target) {
+    simulateClick: function(el, target, focus) {
         var evt = document.createEvent('MouseEvents');
-        // on Mac, pass target as e.metaKey
+        var giveFocus = focus === true;
+        var newTab = giveFocus || target;
+        // on Mac, pass newTab as e.metaKey
         if (navigator.platform.indexOf('Mac') != -1)
-            evt.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, target, 0, null);
-        else // otherwise, pass target as e.ctrlKey
-            evt.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, target, false, false, false, 0, null);
+            evt.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, giveFocus, newTab, 0, null);
+        else // otherwise, pass newTab as e.ctrlKey
+            evt.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, newTab, false, giveFocus, false, 0, null);
         return el.dispatchEvent(evt);
     },
 


### PR DESCRIPTION
This allows users to open a link in new tab **with giving that tab focus** by pressing Ctrl+Shift+Enter, as described in http://productforums.google.com/forum/#!topic/chrome/5gMPvMLirjs:

```
Shift + click opens the link in a new window. 
Ctrl + click opens the link in a new tab but does not give focus to the new tab. 
Shift + Ctrl + click opens the link in a new tab and gives the new tab focus.
```

Ctrl+Enter and Shift+Enter keep the tab unfocused as before.

This still needs to be tested on Mac.
